### PR TITLE
feat(ci): minimal GHA for CI baseline + fix linting violations

### DIFF
--- a/.github/workflows/ci-controller.yaml
+++ b/.github/workflows/ci-controller.yaml
@@ -16,5 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
       - run: make lint
       - run: make build
+      - run: make test

--- a/.github/workflows/ci-controller.yaml
+++ b/.github/workflows/ci-controller.yaml
@@ -1,0 +1,20 @@
+name: CI - Controller
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "ui/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "ui/**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: make lint
+      - run: make build

--- a/.github/workflows/ci-controller.yaml
+++ b/.github/workflows/ci-controller.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.4.0
+        with:
+          path: bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'go.mod', 'go.sum') }}
       - run: make lint
       - run: make build
       - run: make test

--- a/.github/workflows/ci-controller.yaml
+++ b/.github/workflows/ci-controller.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths-ignore:
       - "ui/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-controller.yaml
+++ b/.github/workflows/ci-controller.yaml
@@ -10,6 +10,10 @@ on:
     paths-ignore:
       - "ui/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - '.github_workflows/ci-ui.yaml'
       - 'ui/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -12,6 +12,10 @@ on:
       - '.github_workflows/ci-ui.yaml'
       - 'ui/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/cmd/job/main.go
+++ b/cmd/job/main.go
@@ -36,7 +36,12 @@ func main() {
 		fmt.Printf("Failed to create temporary directory: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			fmt.Printf("Failed to remove temporary directory %s: %v", tmpDir, err)
+			os.Exit(1)
+		}
+	}()
 
 	fmt.Printf("Cloning repository %s @ %s into %s\n", repoURL, targetRevision, tmpDir)
 

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -85,7 +85,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
-func (r *WorkspaceReconciler) constructJobForWorkspace(ctx context.Context, ws *magosprojectiov1alpha1.Workspace, jobName string) (*batchv1.Job, error) {
+func (r *WorkspaceReconciler) constructJobForWorkspace(_ context.Context, ws *magosprojectiov1alpha1.Workspace, jobName string) (*batchv1.Job, error) {
 	envVars := []corev1.EnvVar{
 		{Name: "REPO_URL", Value: ws.Spec.Source.RepoURL},
 		{Name: "TARGET_REVISION", Value: ws.Spec.Source.TargetRevision},


### PR DESCRIPTION
This PR introduces a minimal CI pipeline that ensures the following checks pass:
- `golangci-lint`
- project compilation
- test execution

Additionally, I configured concurrency groups so that, for pull requests only, any in-progress CI run is canceled and replaced when new commits are pushed. I also added caching for the `bin` directory to improve pipeline performance.