### PR TITLE
chart: add missing logs rbac

### DIFF
--- a/charts/magos/templates/clusterrole.yaml
+++ b/charts/magos/templates/clusterrole.yaml
@@ -10,6 +10,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
The workspace controller currently lacks permissions to list pods and read their logs. As a result, [readPolicyViolations](https://github.com/magosproject/magos/blob/cc3141a0a4b404003f9021a750485f5e65d33000/internal/controller/workspace/workspace_controller.go#L638)￼ fails silently, leaving the workspace stuck in the Planning phase.

This adds the required permissions to the `ClusterRole` in the chart.

That said, the behavior itself is still incorrect. I expected the workspace to transition to a Failed state rather than remaining in Planning. This needs to be addressed in the workspace controller logic.