### PR TITLE
terraform: remove SkipChecksumVerification

### DIFF
--- a/internal/terraform/installer.go
+++ b/internal/terraform/installer.go
@@ -44,7 +44,7 @@ func (b *BinaryInstaller) Install(ctx context.Context) (string, error) {
 	if b.exact != "" {
 		ver := version.Must(version.NewVersion(b.exact))
 		// TODO: remove this once hc-install cut a new release; see https://github.com/hashicorp/hc-install/issues/370
-		sources = append(sources, &releases.ExactVersion{Product: product.Terraform, Version: ver, SkipChecksumVerification: true})
+		sources = append(sources, &releases.ExactVersion{Product: product.Terraform, Version: ver})
 	} else if b.constraint != "" {
 		cons := version.MustConstraints(version.NewConstraint(b.constraint))
 		sources = append(sources,


### PR DESCRIPTION
Depends on #41

This solves an issue in the upstream library, hc-install, which was using an expired PGP key to verify and fetch release artifacts from their Release API. We temporarily disabled checksum verification to bypass the expired PGP key from erroring out.