### PR TITLE
fix(chart): give `patch` to the API it's `ClusterRole`

### DIFF
--- a/charts/magos/templates/api-clusterrole.yaml
+++ b/charts/magos/templates/api-clusterrole.yaml
@@ -18,6 +18,5 @@ rules:
   - get
   - list
   - watch
-  - update
   - patch
 {{- end }}

--- a/charts/magos/templates/api-clusterrole.yaml
+++ b/charts/magos/templates/api-clusterrole.yaml
@@ -18,4 +18,6 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 {{- end }}


### PR DESCRIPTION
Fixes the IAM error when running the chart on a real cluster:

```console
time=2026-05-14T07:46:54.246Z level=ERROR msg="failed to patch Workspace" error="workspaces.magosproject.io \"dns-staging\" is forbidden: User \"system:serviceaccount:default:magos-api\" cannot patch resource \"workspaces\" in API gro..
```

This error occured when trying to manually reconcile or enable debug logs via the UI / API.

Manually edited via `k9s` and it solves the issue after manually asigning `patch`:

<img width="1859" height="155" alt="image" src="https://github.com/user-attachments/assets/db89edc2-ce0f-4ffa-af8f-aba895d29d5c" />

