### PR TITLE
feat(ui): apply deeplinking for all pages with tabs

### DIFF
--- a/ui/app/hooks/useTabParam.ts
+++ b/ui/app/hooks/useTabParam.ts
@@ -1,0 +1,14 @@
+import { useSearchParams } from "react-router";
+
+export function useTabParam(defaultTab: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get("tab") ?? defaultTab;
+
+  function setTab(tab: string | null) {
+    if (!tab) return;
+    setSearchParams((prev) => { prev.set("tab", tab); return prev; }, { replace: true });
+  }
+
+  return [activeTab, setTab] as const;
+}
+

--- a/ui/app/routes/project.tsx
+++ b/ui/app/routes/project.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { Link, useLoaderData, useParams } from "react-router";
+import { useTabParam } from "~/hooks/useTabParam";
 import type { CSSProperties } from "react";
 import { IconRefresh } from "@tabler/icons-react";
 import Breadcrumbs from "~/components/Breadcrumbs";
@@ -75,6 +76,8 @@ export default function Project() {
   const flash = useFlashOnChange(phase);
   const flashStyle = { "--flash-color": flashColorVar(phase) } as CSSProperties;
 
+  const [activeTab, setTab] = useTabParam("overview");
+
   return (
     <Stack gap="lg">
       <Breadcrumbs crumbs={[{ label: "Projects", to: "/projects" }, { label: name! }]} />
@@ -100,7 +103,7 @@ export default function Project() {
         </Tooltip>
       </Group>
 
-      <Tabs defaultValue="overview">
+      <Tabs value={activeTab} onChange={setTab}>
         <Tabs.List>
           <Tabs.Tab value="overview">Overview</Tabs.Tab>
           <Tabs.Tab value="workspaces">Workspaces ({workspaces.length})</Tabs.Tab>

--- a/ui/app/routes/rollout.tsx
+++ b/ui/app/routes/rollout.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Button, Group, Stack, Tabs, Title, Tooltip } from "@mantine/core";
 import { useLoaderData, useParams } from "react-router";
+import { useTabParam } from "~/hooks/useTabParam";
 import { IconRefresh } from "@tabler/icons-react";
 import Breadcrumbs from "~/components/Breadcrumbs";
 import KubeBadge from "~/components/KubeBadge";
@@ -48,6 +49,8 @@ export default function Rollout() {
   const flash = useFlashOnChange(`${phase}-${currentStep}`);
   const flashStyle = { "--flash-color": flashColorVar(phase ?? "") } as CSSProperties;
 
+  const [activeTab, setTab] = useTabParam("overview");
+
   return (
     <Stack gap="lg">
       <Breadcrumbs crumbs={[{ label: "Rollouts", to: "/rollouts" }, { label: name! }]} />
@@ -66,7 +69,7 @@ export default function Rollout() {
         </Tooltip>
       </Group>
 
-      <Tabs defaultValue="overview">
+      <Tabs value={activeTab} onChange={setTab}>
         <Tabs.List>
           <Tabs.Tab value="overview">Overview</Tabs.Tab>
           <Tabs.Tab value="steps">Steps</Tabs.Tab>

--- a/ui/app/routes/workspace.tsx
+++ b/ui/app/routes/workspace.tsx
@@ -2,6 +2,7 @@ import { Button, Group, Stack, Tabs, Text, Title } from "@mantine/core";
 import { IconBug, IconRefresh } from "@tabler/icons-react";
 import { useMemo, useState, type CSSProperties } from "react";
 import { useLoaderData, useParams } from "react-router";
+import { useTabParam } from "../hooks/useTabParam";
 import { resourceId } from "../api/resource";
 import Breadcrumbs from "../components/Breadcrumbs";
 import KubeBadge from "../components/KubeBadge";
@@ -76,6 +77,8 @@ export default function Workspace() {
   );
   const canReconcile = phase ? RECONCILABLE_PHASES.has(phase) : false;
   const reconcileDisabled = isSubmittingReconcile || !canReconcile || !namespace || !name;
+
+  const [activeTab, setTab] = useTabParam("overview");
 
   const debugLogsEnabled = ws.metadata?.annotations?.["magosproject.io/tf-log-level"] === "DEBUG";
 
@@ -153,7 +156,7 @@ export default function Workspace() {
         </Group>
       </Group>
 
-      <Tabs defaultValue="overview">
+      <Tabs value={activeTab} onChange={setTab}>
         <Tabs.List>
           <Tabs.Tab value="overview">Overview</Tabs.Tab>
           <Tabs.Tab value="runs">Runs</Tabs.Tab>


### PR DESCRIPTION
This PR applies shared logic for deeplinking to be used on all pages that use the `Tabs` component. This allows page refreshes on tabs via a query parameter.

E.g.: `http://localhost:5173/workspaces/default/dns-dev?tab=runs`