### PR TITLE
feat(logging): show the `podName` in the UI instead of the `runId` + re-use the same logging stream

### DIFF
--- a/api/internal/api/docs/swagger.json
+++ b/api/internal/api/docs/swagger.json
@@ -161,10 +161,27 @@
                         "type": "string"
                     },
                     "type": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/service.RunLogStreamEventType"
                     }
                 },
                 "type": "object"
+            },
+            "service.RunLogStreamEventType": {
+                "enum": [
+                    "phase_start",
+                    "status",
+                    "line",
+                    "error",
+                    "eof"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "RunLogStreamEventTypePhaseStart",
+                    "RunLogStreamEventTypeStatus",
+                    "RunLogStreamEventTypeLine",
+                    "RunLogStreamEventTypeError",
+                    "RunLogStreamEventTypeEOF"
+                ]
             },
             "service.VariableSetEvent": {
                 "properties": {

--- a/api/internal/api/docs/swagger.json
+++ b/api/internal/api/docs/swagger.json
@@ -1851,14 +1851,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "description": "Phase to stream: plan or apply (defaults to apply)",
-                        "in": "query",
-                        "name": "phase",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 ],
                 "responses": {
@@ -1893,7 +1885,7 @@
                         "description": "Not Found"
                     }
                 },
-                "summary": "Stream live logs from the active phase of the in-progress plan and apply run",
+                "summary": "Stream live logs from the in-progress plan and apply run",
                 "tags": [
                     "Workspace"
                 ]

--- a/api/internal/api/handlers/workspace_handler.go
+++ b/api/internal/api/handlers/workspace_handler.go
@@ -334,12 +334,11 @@ func (h *WorkspaceHandler) RecordRunPhase(w http.ResponseWriter, r *http.Request
 
 // StreamCurrentRunLog godoc
 //
-//	@Summary	Stream live logs from the active phase of the in-progress plan and apply run
+//	@Summary	Stream live logs from the in-progress plan and apply run
 //	@Tags		Workspace
 //	@Produce	text/event-stream
 //	@Param		namespace	path		string	true	"Namespace"
 //	@Param		name		path		string	true	"Name"
-//	@Param		phase		query		string	false	"Phase to stream: plan or apply (defaults to apply)"
 //	@Success	200			{object}	service.RunLogStreamEvent
 //	@Failure	400			{object}	ErrorResponse
 //	@Failure	404			{object}	ErrorResponse
@@ -358,9 +357,8 @@ func (h *WorkspaceHandler) StreamCurrentRunLog(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	phase := parseRunPhase(r.URL.Query().Get("phase"))
 	StreamSSE(w, r, func(ctx context.Context) <-chan service.RunLogStreamEvent {
-		return h.service.StreamCurrentRunLogs(ctx, namespace, name, phase)
+		return h.service.StreamCurrentRunLogs(ctx, namespace, name)
 	})
 }
 

--- a/api/internal/service/workspace_service.go
+++ b/api/internal/service/workspace_service.go
@@ -83,13 +83,24 @@ type RunListResponse struct {
 	NextCursor string            `json:"nextCursor,omitempty"`
 }
 
+// RunLogStreamEventType identifies the kind of a RunLogStreamEvent.
+type RunLogStreamEventType string
+
+const (
+	RunLogStreamEventTypePhaseStart RunLogStreamEventType = "phase_start"
+	RunLogStreamEventTypeStatus     RunLogStreamEventType = "status"
+	RunLogStreamEventTypeLine       RunLogStreamEventType = "line"
+	RunLogStreamEventTypeError      RunLogStreamEventType = "error"
+	RunLogStreamEventTypeEOF        RunLogStreamEventType = "eof"
+)
+
 type RunLogStreamEvent struct {
-	Type    string               `json:"type"`
-	RunID   string               `json:"runID,omitempty"`
-	Phase   apiv1alpha1.RunPhase `json:"phase,omitempty"`
-	PodName string               `json:"podName,omitempty"`
-	Line    string               `json:"line,omitempty"`
-	Message string               `json:"message,omitempty"`
+	Type    RunLogStreamEventType `json:"type"`
+	RunID   string                `json:"runID,omitempty"`
+	Phase   apiv1alpha1.RunPhase  `json:"phase,omitempty"`
+	PodName string                `json:"podName,omitempty"`
+	Line    string                `json:"line,omitempty"`
+	Message string                `json:"message,omitempty"`
 }
 
 type workspaceService struct {
@@ -297,24 +308,24 @@ func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, 
 		defer close(ch)
 
 		if s.kube == nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Message: "kubernetes client is not configured"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeError, Message: "kubernetes client is not configured"})
 			return
 		}
 
 		workspace, err := s.Get(ctx, namespace, name)
 		if err != nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Message: "workspace not found"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeError, Message: "workspace not found"})
 			return
 		}
 
 		runID := workspace.Status.CurrentRunID
 		if runID == "" {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", Message: "no active run"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeStatus, Message: "no active run"})
 			return
 		}
 
 		for _, phase := range []apiv1alpha1.RunPhase{apiv1alpha1.RunPhasePlan, apiv1alpha1.RunPhaseApply} {
-			if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "phase_start", RunID: runID, Phase: phase}) {
+			if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypePhaseStart, RunID: runID, Phase: phase}) {
 				return
 			}
 
@@ -323,11 +334,11 @@ func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, 
 				break
 			}
 			if err != nil {
-				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, Message: err.Error()})
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeError, RunID: runID, Phase: phase, Message: err.Error()})
 				return
 			}
 
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", RunID: runID, Phase: phase, PodName: pod.Name, Message: "streaming"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeStatus, RunID: runID, Phase: phase, PodName: pod.Name, Message: "streaming"})
 
 			req := s.kube.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 				Container: "job",
@@ -335,7 +346,7 @@ func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, 
 			})
 			stream, err := req.Stream(ctx)
 			if err != nil {
-				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("open pod logs: %v", err)})
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeError, RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("open pod logs: %v", err)})
 				return
 			}
 
@@ -343,7 +354,7 @@ func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, 
 			scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 			for scanner.Scan() {
 				if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{
-					Type:    "line",
+					Type:    RunLogStreamEventTypeLine,
 					RunID:   runID,
 					Phase:   phase,
 					PodName: pod.Name,
@@ -355,13 +366,13 @@ func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, 
 			}
 			if scanErr := scanner.Err(); scanErr != nil && ctx.Err() == nil {
 				_ = stream.Close()
-				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("read pod logs: %v", scanErr)})
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeError, RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("read pod logs: %v", scanErr)})
 				return
 			}
 			_ = stream.Close()
 		}
 
-		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "eof", RunID: runID, Message: "log stream completed"})
+		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: RunLogStreamEventTypeEOF, RunID: runID, Message: "log stream completed"})
 	}()
 
 	return ch

--- a/api/internal/service/workspace_service.go
+++ b/api/internal/service/workspace_service.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -67,7 +68,7 @@ type WorkspaceService interface {
 	GetRunPhaseLog(ctx context.Context, namespace, name, runID string, phase apiv1alpha1.RunPhase) (io.ReadCloser, error)
 	RecordRun(ctx context.Context, namespace, name string, run apiv1alpha1.Run) error
 	RecordRunPhase(ctx context.Context, namespace, name, runID string, phase apiv1alpha1.RunPhase, run apiv1alpha1.Run) error
-	StreamCurrentRunLogs(ctx context.Context, namespace, name string, phase apiv1alpha1.RunPhase) <-chan RunLogStreamEvent
+	StreamCurrentRunLogs(ctx context.Context, namespace, name string) <-chan RunLogStreamEvent
 }
 
 // RunStore stores searchable run metadata.
@@ -287,69 +288,80 @@ func (s *workspaceService) RecordRunPhase(ctx context.Context, namespace, name, 
 	return s.runStore.UpsertRun(ctx, namespace, name, run)
 }
 
-func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, name string, phase apiv1alpha1.RunPhase) <-chan RunLogStreamEvent {
+var errRunEnded = errors.New("run ended")
+
+func (s *workspaceService) StreamCurrentRunLogs(ctx context.Context, namespace, name string) <-chan RunLogStreamEvent {
 	ch := make(chan RunLogStreamEvent)
 
 	go func() {
 		defer close(ch)
 
 		if s.kube == nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Phase: phase, Message: "kubernetes client is not configured"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Message: "kubernetes client is not configured"})
 			return
 		}
 
 		workspace, err := s.Get(ctx, namespace, name)
 		if err != nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Phase: phase, Message: "workspace not found"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", Message: "workspace not found"})
 			return
 		}
 
 		runID := workspace.Status.CurrentRunID
 		if runID == "" {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", Phase: phase, Message: "no active run"})
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", Message: "no active run"})
 			return
 		}
 
-		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", RunID: runID, Phase: phase, Message: "waiting for log stream"})
-
-		pod, err := s.waitForRunPod(ctx, namespace, name, runID, phase)
-		if err != nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, Message: err.Error()})
-			return
-		}
-
-		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", RunID: runID, Phase: phase, PodName: pod.Name, Message: "streaming"})
-
-		req := s.kube.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-			Container: "job",
-			Follow:    true,
-		})
-		stream, err := req.Stream(ctx)
-		if err != nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("open pod logs: %v", err)})
-			return
-		}
-		defer func() { _ = stream.Close() }()
-
-		scanner := bufio.NewScanner(stream)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{
-				Type:    "line",
-				RunID:   runID,
-				Phase:   phase,
-				PodName: pod.Name,
-				Line:    scanner.Text(),
-			}) {
+		for _, phase := range []apiv1alpha1.RunPhase{apiv1alpha1.RunPhasePlan, apiv1alpha1.RunPhaseApply} {
+			if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "phase_start", RunID: runID, Phase: phase}) {
 				return
 			}
-		}
-		if err := scanner.Err(); err != nil && ctx.Err() == nil {
-			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("read pod logs: %v", err)})
-			return
+
+			pod, err := s.waitForRunPod(ctx, namespace, name, runID, phase)
+			if errors.Is(err, errRunEnded) {
+				break
+			}
+			if err != nil {
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, Message: err.Error()})
+				return
+			}
+
+			sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "status", RunID: runID, Phase: phase, PodName: pod.Name, Message: "streaming"})
+
+			req := s.kube.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: "job",
+				Follow:    true,
+			})
+			stream, err := req.Stream(ctx)
+			if err != nil {
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("open pod logs: %v", err)})
+				return
+			}
+
+			scanner := bufio.NewScanner(stream)
+			scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+			for scanner.Scan() {
+				if !sendRunLogEvent(ctx, ch, RunLogStreamEvent{
+					Type:    "line",
+					RunID:   runID,
+					Phase:   phase,
+					PodName: pod.Name,
+					Line:    scanner.Text(),
+				}) {
+					_ = stream.Close()
+					return
+				}
+			}
+			if scanErr := scanner.Err(); scanErr != nil && ctx.Err() == nil {
+				_ = stream.Close()
+				sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "error", RunID: runID, Phase: phase, PodName: pod.Name, Message: fmt.Sprintf("read pod logs: %v", scanErr)})
+				return
+			}
+			_ = stream.Close()
 		}
 
-		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "eof", RunID: runID, Phase: phase, PodName: pod.Name, Message: "log stream completed"})
+		sendRunLogEvent(ctx, ch, RunLogStreamEvent{Type: "eof", RunID: runID, Message: "log stream completed"})
 	}()
 
 	return ch
@@ -374,7 +386,7 @@ func (s *workspaceService) waitForRunPod(ctx context.Context, namespace, workspa
 			return nil, err
 		}
 		if workspace.Status.CurrentRunID != runID {
-			return nil, fmt.Errorf("run changed while waiting for log stream")
+			return nil, errRunEnded
 		}
 
 		pod, err := s.findRunPod(ctx, namespace, workspaceName, runID, phase)
@@ -412,12 +424,12 @@ func (s *workspaceService) findRunPod(ctx context.Context, namespace, workspaceN
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		switch pod.Status.Phase {
-		case corev1.PodPending, corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed:
+		case corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed:
 			return pod, nil
 		}
 	}
 
-	return &pods.Items[0], nil
+	return nil, fmt.Errorf("no running pod found for current %s run yet", phase)
 }
 
 type gzipReadCloser struct {

--- a/ui/app/api/types.gen.ts
+++ b/ui/app/api/types.gen.ts
@@ -1054,8 +1054,10 @@ export interface components {
             phase?: components["schemas"]["v1alpha1.RunPhase"];
             podName?: string;
             runID?: string;
-            type?: string;
+            type?: components["schemas"]["service.RunLogStreamEventType"];
         };
+        /** @enum {string} */
+        "service.RunLogStreamEventType": "phase_start" | "status" | "line" | "error" | "eof";
         "service.VariableSetEvent": {
             object?: components["schemas"]["v1alpha1.VariableSet"];
             type?: components["schemas"]["watch.EventType"];

--- a/ui/app/api/types.gen.ts
+++ b/ui/app/api/types.gen.ts
@@ -779,13 +779,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Stream live logs from the active phase of the in-progress plan and apply run */
+        /** Stream live logs from the in-progress plan and apply run */
         get: {
             parameters: {
-                query?: {
-                    /** @description Phase to stream: plan or apply (defaults to apply) */
-                    phase?: string;
-                };
+                query?: never;
                 header?: never;
                 path: {
                     /** @description Namespace */

--- a/ui/app/api/types.ts
+++ b/ui/app/api/types.ts
@@ -14,6 +14,8 @@ export type LabelSelector = components["schemas"]["v1.LabelSelector"];
 export type RunPhaseSummary = components["schemas"]["v1alpha1.RunPhaseSummary"];
 export type Run = components["schemas"]["v1alpha1.Run"];
 export type RunListResponse = components["schemas"]["service.RunListResponse"];
+export type RunLogStreamEvent = components["schemas"]["service.RunLogStreamEvent"];
+export type RunLogStreamEventType = components["schemas"]["service.RunLogStreamEventType"];
 
 export type ResourceObject = {
   metadata?: ObjectMeta;

--- a/ui/app/components/WorkspaceLiveConsole.tsx
+++ b/ui/app/components/WorkspaceLiveConsole.tsx
@@ -2,26 +2,27 @@ import { Code, Group, Loader, Text, Title } from "@mantine/core";
 import AnsiToHtml from "ansi-to-html";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiUrl } from "../api/base";
-import type { Run } from "../api/types";
+import type { Phase, Run, RunLogStreamEvent, RunLogStreamEventType } from "../api/types";
 
-type StreamEvent = {
-  type?: "status" | "line" | "error" | "phase_start" | "eof";
-  runID?: string;
-  phase?: "plan" | "apply";
-  podName?: string;
-  line?: string;
-  message?: string;
-};
+const EVENT = {
+  PhaseStart: "phase_start",
+  Status: "status",
+  Line: "line",
+  Error: "error",
+  EOF: "eof",
+} as const satisfies Record<string, RunLogStreamEventType>;
 
 interface Props {
   namespace: string;
   workspaceName: string;
+  phase?: Phase;
   currentRunID?: string;
 }
 
 export default function WorkspaceLiveConsole({
   namespace,
   workspaceName,
+  phase,
   currentRunID,
 }: Props) {
   const [status, setStatus] = useState("Loading latest completed run log");
@@ -31,7 +32,7 @@ export default function WorkspaceLiveConsole({
   const viewportRef = useRef<HTMLDivElement>(null);
   const pendingRef = useRef<string[]>([]);
   const revealTimerRef = useRef<number | null>(null);
-  const isActive = Boolean(currentRunID);
+  const isActive = phase === "Planning" || phase === "Planned" || phase === "Applying";
   const streamKey = currentRunID ?? "";
 
   const [contentState, setContentState] = useState<{ key: string; value: string | null }>({
@@ -120,9 +121,9 @@ export default function WorkspaceLiveConsole({
     );
 
     source.onmessage = (event) => {
-      const payload = JSON.parse(event.data) as StreamEvent;
+      const payload = JSON.parse(event.data) as RunLogStreamEvent;
       switch (payload.type) {
-        case "phase_start":
+        case EVENT.PhaseStart:
           // Clear the console when the apply phase begins. For the plan phase
           // (the first event on a fresh connection) there is nothing to clear.
           if (payload.phase === "apply") {
@@ -133,19 +134,19 @@ export default function WorkspaceLiveConsole({
           setCurrentStreamPhase(payload.phase ?? null);
           setPodName(null);
           break;
-        case "status":
+        case EVENT.Status:
           if (payload.podName) setPodName(payload.podName);
           break;
-        case "line":
+        case EVENT.Line:
           pending.push(payload.line ?? "");
           if (revealTimerRef.current == null) {
             revealTimerRef.current = window.setInterval(flushPendingLines, 60);
           }
           break;
-        case "error":
+        case EVENT.Error:
           setStatus(payload.message || "Error streaming logs");
           break;
-        case "eof":
+        case EVENT.EOF:
           setStreamDone(true);
           setStatus("Run completed");
           source.close();
@@ -184,12 +185,16 @@ export default function WorkspaceLiveConsole({
       <Group gap="xs">
         {loading && <Loader size="xs" />}
         <Text size="sm" c="dimmed">
-          {isActive && !streamDone
-            ? currentStreamPhase
-              ? podName
-                ? `Streaming ${currentStreamPhase} logs for pod ${podName}`
-                : `Waiting for ${currentStreamPhase} logs`
-              : "Connecting..."
+          {isActive
+            ? streamDone
+              ? currentStreamPhase && podName
+                ? `Run completed – showing ${currentStreamPhase} logs for pod ${podName}`
+                : "Run completed"
+              : currentStreamPhase
+                ? podName
+                  ? `Streaming ${currentStreamPhase} logs for pod ${podName}`
+                  : `Waiting for ${currentStreamPhase} logs`
+                : "Connecting..."
             : status}
         </Text>
       </Group>

--- a/ui/app/components/WorkspaceLiveConsole.tsx
+++ b/ui/app/components/WorkspaceLiveConsole.tsx
@@ -40,6 +40,7 @@ export default function WorkspaceLiveConsole({
   currentRunID,
 }: Props) {
   const [status, setStatus] = useState("Loading latest completed run log");
+  const [podName, setPodName] = useState<string | null>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const pendingRef = useRef<string[]>([]);
   const revealTimerRef = useRef<number | null>(null);
@@ -157,6 +158,7 @@ export default function WorkspaceLiveConsole({
       const payload = JSON.parse(event.data) as StreamEvent;
       switch (payload.type) {
         case "status":
+          if (payload.podName) setPodName(payload.podName);
           break;
         case "line":
           pending.push(payload.line ?? "");
@@ -181,6 +183,7 @@ export default function WorkspaceLiveConsole({
     return () => {
       source.close();
       stopRevealTimer();
+      setPodName(null);
       while (pending.length > 0) {
         flushPendingLines();
       }
@@ -204,8 +207,8 @@ export default function WorkspaceLiveConsole({
         <Text size="sm" c="dimmed">
           {isActive && currentRunID
             ? contentState.key === streamKey && content
-              ? `Streaming ${streamPhase} logs for job ${currentRunID}`
-              : `Waiting for ${streamPhase} logs from job ${currentRunID}`
+              ? `Streaming ${streamPhase} logs for pod ${podName}`
+              : `Waiting for ${streamPhase} logs from pod ${podName}`
             : status}
         </Text>
       </Group>

--- a/ui/app/components/WorkspaceLiveConsole.tsx
+++ b/ui/app/components/WorkspaceLiveConsole.tsx
@@ -2,10 +2,10 @@ import { Code, Group, Loader, Text, Title } from "@mantine/core";
 import AnsiToHtml from "ansi-to-html";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiUrl } from "../api/base";
-import type { Phase, Run } from "../api/types";
+import type { Run } from "../api/types";
 
 type StreamEvent = {
-  type?: "status" | "line" | "error" | "eof";
+  type?: "status" | "line" | "error" | "phase_start" | "eof";
   runID?: string;
   phase?: "plan" | "apply";
   podName?: string;
@@ -16,50 +16,25 @@ type StreamEvent = {
 interface Props {
   namespace: string;
   workspaceName: string;
-  phase?: Phase;
   currentRunID?: string;
-}
-
-// activeStreamPhase returns the log phase to stream for the current workspace
-// phase, or null when no active run is in progress.
-function activeStreamPhase(phase?: Phase): "plan" | "apply" | null {
-  switch (phase) {
-    case "Planning":
-      return "plan";
-    case "Applying":
-      return "apply";
-    default:
-      return null;
-  }
 }
 
 export default function WorkspaceLiveConsole({
   namespace,
   workspaceName,
-  phase,
   currentRunID,
 }: Props) {
   const [status, setStatus] = useState("Loading latest completed run log");
   const [podName, setPodName] = useState<string | null>(null);
+  const [streamDone, setStreamDone] = useState(false);
+  const [currentStreamPhase, setCurrentStreamPhase] = useState<"plan" | "apply" | null>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const pendingRef = useRef<string[]>([]);
   const revealTimerRef = useRef<number | null>(null);
-  const streamPhase = activeStreamPhase(phase);
-  const isActive = Boolean(streamPhase && currentRunID);
-  // streamKey changes whenever the run or active phase changes, causing all
-  // effects that depend on it to re-run with a clean slate.
-  const streamKey = useMemo(
-    () => `${currentRunID ?? ""}:${streamPhase ?? ""}`,
-    [streamPhase, currentRunID]
-  );
+  const isActive = Boolean(currentRunID);
+  const streamKey = currentRunID ?? "";
 
-  // Content is stored together with the streamKey it was produced for.
-  // When streamKey changes the derived `content` value is automatically null
-  // (loading), so no explicit reset logic is needed anywhere.
-  const [contentState, setContentState] = useState<{
-    key: string;
-    value: string | null;
-  }>({
+  const [contentState, setContentState] = useState<{ key: string; value: string | null }>({
     key: streamKey,
     value: null,
   });
@@ -88,17 +63,13 @@ export default function WorkspaceLiveConsole({
     if (pending.length === 0) stopRevealTimer();
   }, [streamKey, stopRevealTimer]);
 
-  // When there is no active run, load the most recent completed run's apply
-  // log (falling back to the plan log) so the console is never blank.
   useEffect(() => {
     if (isActive) return;
 
     const controller = new AbortController();
 
     fetch(
-      apiUrl(
-        `/apis/magosproject.io/v1alpha1/workspaces/${namespace}/${workspaceName}/runs?limit=1`
-      ),
+      apiUrl(`/apis/magosproject.io/v1alpha1/workspaces/${namespace}/${workspaceName}/runs?limit=1`),
       { signal: controller.signal, cache: "no-store" }
     )
       .then(async (response) => {
@@ -112,15 +83,12 @@ export default function WorkspaceLiveConsole({
           setStatus("No logs recorded yet");
           return;
         }
-
-        // Prefer the apply log; fall back to plan when apply did not run.
         const logPhase = latest.apply ? "apply" : latest.plan ? "plan" : null;
         if (!logPhase) {
           setContent("");
           setStatus("No logs recorded yet");
           return;
         }
-
         const response = await fetch(
           apiUrl(
             `/apis/magosproject.io/v1alpha1/workspaces/${namespace}/${workspaceName}/runs/${latest.runID}/log?phase=${logPhase}`
@@ -141,22 +109,30 @@ export default function WorkspaceLiveConsole({
     return () => controller.abort();
   }, [isActive, namespace, workspaceName, streamKey, setContent]);
 
-  // Stream live logs from the active run's pod when a plan or apply is in
-  // progress. The EventSource is torn down and rebuilt whenever streamKey
-  // changes so stale streams from a previous run do not bleed into the next.
   useEffect(() => {
-    if (!isActive || !streamPhase) return;
+    if (!isActive) return;
 
     const pending = pendingRef.current;
     const source = new EventSource(
       apiUrl(
-        `/apis/magosproject.io/v1alpha1/workspaces/${namespace}/${workspaceName}/runs/current/log/stream?phase=${streamPhase}`
+        `/apis/magosproject.io/v1alpha1/workspaces/${namespace}/${workspaceName}/runs/current/log/stream`
       )
     );
 
     source.onmessage = (event) => {
       const payload = JSON.parse(event.data) as StreamEvent;
       switch (payload.type) {
+        case "phase_start":
+          // Clear the console when the apply phase begins. For the plan phase
+          // (the first event on a fresh connection) there is nothing to clear.
+          if (payload.phase === "apply") {
+            pending.splice(0);
+            stopRevealTimer();
+            setContentState({ key: streamKey, value: "" });
+          }
+          setCurrentStreamPhase(payload.phase ?? null);
+          setPodName(null);
+          break;
         case "status":
           if (payload.podName) setPodName(payload.podName);
           break;
@@ -167,10 +143,11 @@ export default function WorkspaceLiveConsole({
           }
           break;
         case "error":
-          setStatus(payload.message || `Error streaming ${streamPhase} logs`);
+          setStatus(payload.message || "Error streaming logs");
           break;
         case "eof":
-          setStatus("Run phase completed");
+          setStreamDone(true);
+          setStatus("Run completed");
           source.close();
           break;
       }
@@ -184,11 +161,13 @@ export default function WorkspaceLiveConsole({
       source.close();
       stopRevealTimer();
       setPodName(null);
+      setStreamDone(false);
+      setCurrentStreamPhase(null);
       while (pending.length > 0) {
         flushPendingLines();
       }
     };
-  }, [streamPhase, isActive, namespace, streamKey, workspaceName, currentRunID, flushPendingLines, stopRevealTimer]);
+  }, [isActive, namespace, streamKey, workspaceName, flushPendingLines, stopRevealTimer]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -205,10 +184,12 @@ export default function WorkspaceLiveConsole({
       <Group gap="xs">
         {loading && <Loader size="xs" />}
         <Text size="sm" c="dimmed">
-          {isActive && currentRunID
-            ? contentState.key === streamKey && content
-              ? `Streaming ${streamPhase} logs for pod ${podName}`
-              : `Waiting for ${streamPhase} logs from pod ${podName}`
+          {isActive && !streamDone
+            ? currentStreamPhase
+              ? podName
+                ? `Streaming ${currentStreamPhase} logs for pod ${podName}`
+                : `Waiting for ${currentStreamPhase} logs`
+              : "Connecting..."
             : status}
         </Text>
       </Group>

--- a/ui/app/components/WorkspaceRunHistory.tsx
+++ b/ui/app/components/WorkspaceRunHistory.tsx
@@ -125,6 +125,11 @@ function LogPane({ namespace, workspaceName, runID, phase, summary }: LogPanePro
             {formatDateTime(summary.startedAt)} · {formatDuration(summary.startedAt, summary.finishedAt)}
           </Text>
         )}
+        {summary.podName && (
+          <Text size="xs" c="dimmed">
+            pod: <Code fz="xs">{summary.podName}</Code>
+          </Text>
+        )}
       </Group>
 
       {loading && (

--- a/ui/app/routes/workspace.tsx
+++ b/ui/app/routes/workspace.tsx
@@ -213,7 +213,6 @@ export default function Workspace() {
               <WorkspaceLiveConsole
                 namespace={namespace}
                 workspaceName={name}
-                phase={phase}
                 currentRunID={ws.status?.currentRunID}
               />
             )}

--- a/ui/app/routes/workspace.tsx
+++ b/ui/app/routes/workspace.tsx
@@ -213,6 +213,7 @@ export default function Workspace() {
               <WorkspaceLiveConsole
                 namespace={namespace}
                 workspaceName={name}
+                phase={phase}
                 currentRunID={ws.status?.currentRunID}
               />
             )}


### PR DESCRIPTION
Shows the `podName` in the UI while waiting for logs or looking into historical logs instead of solely the `runId`. Also this PR introduces some logging stream improvements:

- Instead of resetting the same `EventSource` connection 6 times per whole plan/apply cycle, it now keeps 1 event stream open for the whole run.
- The event stream now sends the `phase_start` event from the server so the UI knows it needs to clear the console