### PR TITLE
workspace: share working tree across plan and apply pods

### DIFF
--- a/cmd/job/main.go
+++ b/cmd/job/main.go
@@ -49,7 +49,7 @@ type Config struct {
 	GitSSHKey      string
 	JobType        string
 	PlanFile       string
-	RunID          string // identifies the per-run subdirectory on the workspace PVC
+	RunID          string
 	PolicySelector string // a label selector for kyverno policies to evaluate the plan against, e.g. "env=prod"
 	TFLogLevel     string // TF_LOG level (TRACE, DEBUG, INFO, WARN, ERROR); empty means logging is suppressed
 }

--- a/cmd/job/main.go
+++ b/cmd/job/main.go
@@ -49,9 +49,15 @@ type Config struct {
 	GitSSHKey      string
 	JobType        string
 	PlanFile       string
+	RunID          string // identifies the per-run subdirectory on the workspace PVC
 	PolicySelector string // a label selector for kyverno policies to evaluate the plan against, e.g. "env=prod"
 	TFLogLevel     string // TF_LOG level (TRACE, DEBUG, INFO, WARN, ERROR); empty means logging is suppressed
 }
+
+const (
+	jobTypePlan  = "plan"
+	jobTypeApply = "apply"
+)
 
 // loadConfig reads the job configuration from environment variables. The
 // workspace controller sets these when it constructs the Job spec, so env vars
@@ -71,16 +77,24 @@ func loadConfig() (*Config, error) {
 		GitSSHKey:      os.Getenv("GIT_SSH_PRIVATE_KEY"),
 		JobType:        os.Getenv("MAGOS_JOB_TYPE"),
 		PlanFile:       os.Getenv("MAGOS_PLAN_FILE"),
+		RunID:          os.Getenv("MAGOS_RUN_ID"),
 		PolicySelector: os.Getenv("MAGOS_POLICY_SELECTOR"),
 		TFLogLevel:     os.Getenv("MAGOS_TF_LOG_LEVEL"),
 	}
 
-	if cfg.RepoURL == "" || cfg.TargetRevision == "" || cfg.TFVersion == "" || cfg.JobType == "" || cfg.PlanFile == "" {
-		return nil, errors.New("REPO_URL, TARGET_REVISION, TF_VERSION, MAGOS_JOB_TYPE, and MAGOS_PLAN_FILE are required")
+	if cfg.RepoURL == "" || cfg.TFVersion == "" || cfg.JobType == "" || cfg.PlanFile == "" || cfg.RunID == "" {
+		return nil, errors.New("REPO_URL, TF_VERSION, MAGOS_JOB_TYPE, MAGOS_PLAN_FILE, and MAGOS_RUN_ID are required")
 	}
 
-	if cfg.JobType != "plan" && cfg.JobType != "apply" {
+	if cfg.JobType != jobTypePlan && cfg.JobType != jobTypeApply {
 		return nil, fmt.Errorf("invalid MAGOS_JOB_TYPE: %s (must be 'plan' or 'apply')", cfg.JobType)
+	}
+
+	// Only the plan pod clones the repo, so TARGET_REVISION is only required
+	// for plan jobs. The apply pod inherits the working tree the plan pod left
+	// on the shared PVC and does not resolve any git ref of its own.
+	if cfg.JobType == jobTypePlan && cfg.TargetRevision == "" {
+		return nil, errors.New("TARGET_REVISION is required for plan jobs")
 	}
 
 	return cfg, nil
@@ -118,12 +132,93 @@ func getAuthMethod(cfg *Config) (transport.AuthMethod, error) {
 	return nil, nil // Public repository fallback
 }
 
+// runsBase is the parent for per-run subdirectories on the workspace PVC.
+const runsBase = "/workspace-data/runs"
+
+// runDir returns the directory on the PVC for a given run.
+func runDir(runID string) string {
+	return filepath.Join(runsBase, runID)
+}
+
+// sourcePath returns the source tree path for a given run.
+func sourcePath(runID string) string {
+	return filepath.Join(runDir(runID), "source")
+}
+
+// clearSourceDir removes the working tree at path. No-op if it is absent.
+func clearSourceDir(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("failed to clear source dir %q: %w", path, err)
+	}
+	return nil
+}
+
+// pruneOldRunDirs removes every per-run directory on the PVC except the
+// one for currentRunID. The plan pod calls this at startup to clean up
+// orphans left by previous failed or interrupted runs.
+func pruneOldRunDirs(currentRunID string) error {
+	return pruneRunDirsIn(runsBase, currentRunID)
+}
+
+// pruneRunDirsIn removes every subdirectory in baseDir except the one
+// named currentRunID. Files in baseDir are left alone. A failure on one
+// entry is logged and skipped so a single bad entry does not block the
+// run. pruneOldRunDirs uses this with runsBase; tests pass a tempdir.
+func pruneRunDirsIn(baseDir, currentRunID string) error {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list run dirs in %q: %w", baseDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == currentRunID {
+			continue
+		}
+		path := filepath.Join(baseDir, e.Name())
+		if err := os.RemoveAll(path); err != nil {
+			log.Printf("Warning: failed to prune stale run dir %s: %v", path, err)
+			continue
+		}
+		log.Printf("Pruned stale run dir %s", path)
+	}
+	return nil
+}
+
+// validateSourceDir checks that the apply pod's working tree is present
+// and that terraform init ran in it. Fails fast otherwise.
+func validateSourceDir(sourceDir, tfPath string) error {
+	if _, err := os.Stat(sourceDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf(
+				"source directory %q is missing; the plan pod did not prepare a working tree for this run",
+				sourceDir,
+			)
+		}
+		return fmt.Errorf("failed to stat source directory %q: %w", sourceDir, err)
+	}
+
+	tfDir := filepath.Join(sourceDir, tfPath, ".terraform")
+	if _, err := os.Stat(tfDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf(
+				"expected .terraform directory at %q is missing; the plan pod did not complete terraform init for this run",
+				tfDir,
+			)
+		}
+		return fmt.Errorf("failed to stat %q: %w", tfDir, err)
+	}
+
+	return nil
+}
+
 // cloneRepository performs a shallow clone of the configured repository into
 // dest and checks out the exact revision the controller asked for. The shallow
 // clone keeps pod startup fast and avoids pulling years of history the job is
-// never going to read. Resolving the revision explicitly (rather than relying
-// on the clone's default branch) means a branch moving between the plan and
-// apply phases cannot silently change what we are about to apply.
+// never going to read. Only the plan pod calls this; the apply pod reuses the
+// working tree the plan pod produced. dest is expected to be empty or missing;
+// callers that may have a stale tree on disk should call clearSourceDir first.
 func cloneRepository(ctx context.Context, cfg *Config, dest string) error {
 	auth, err := getAuthMethod(cfg)
 	if err != nil {
@@ -217,7 +312,7 @@ func execTerraform(ctx context.Context, cfg *Config, cloneDir string) error {
 	}
 
 	switch cfg.JobType {
-	case "plan":
+	case jobTypePlan:
 		log.Println("Running 'terraform plan'...")
 		var planOpts []tfexec.PlanOption
 		if cfg.TFVarsPath != "" {
@@ -252,8 +347,19 @@ func execTerraform(ctx context.Context, cfg *Config, cloneDir string) error {
 			}
 		}
 
-	case "apply":
+	case jobTypeApply:
 		log.Printf("Running 'terraform apply' using plan %s...", cfg.PlanFile)
+
+		// Always remove the run dir when the apply pod exits, success or
+		// failure. The next plan's prune is the fallback for the case
+		// where the pod is killed before this defer runs.
+		defer func() {
+			runPath := runDir(cfg.RunID)
+			log.Printf("Removing run directory %s...", runPath)
+			if err := os.RemoveAll(runPath); err != nil {
+				log.Printf("Warning: failed to remove run dir: %v", err)
+			}
+		}()
 
 		// Hack to handle local kind (Kubernetes-in-Docker) filesystem lag. My
 		// (@bschaatsbergen) container runtime (using sshfs or virtiofs under
@@ -476,12 +582,9 @@ func logTerraformEnvVars() {
 	log.Printf("Loaded %d Terraform input(s) from VariableSets: %s", len(names), strings.Join(names, ", "))
 }
 
-// run drives a single job from start to finish. It configures logging, loads
-// and validates the environment configuration, creates a per pod temporary
-// workspace under /tmp, clones the repository into it, and then hands off to
-// execTerraform. Each pod gets its own temp directory so concurrent jobs cannot
-// see each other's files, and the deferred RemoveAll makes sure we do not leave
-// stale clones behind when the pod terminates.
+// run drives a single job. Plan pods clone into
+// /workspace-data/runs/<runID>/source; apply pods reuse that tree. A
+// successful apply removes the run's directory.
 func run() error {
 	// Prefix every log line with [magos-job] so pod logs are easy to scan.
 	log.SetFlags(log.LstdFlags | log.Lmsgprefix)
@@ -500,23 +603,33 @@ func run() error {
 	// names-only.
 	logTerraformEnvVars()
 
-	tmpDir, err := os.MkdirTemp("", "magos-workspace-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temporary workspace directory: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			log.Printf("Warning: failed to remove temporary workspace %q: %v", tmpDir, err)
-		}
-	}()
-
 	ctx := context.Background()
+	src := sourcePath(cfg.RunID)
 
-	if err := cloneRepository(ctx, cfg, tmpDir); err != nil {
-		return err
+	switch cfg.JobType {
+	case jobTypePlan:
+		// Best-effort cleanup of orphan run dirs.
+		if err := pruneOldRunDirs(cfg.RunID); err != nil {
+			log.Printf("Warning: failed to prune stale run dirs: %v", err)
+		}
+		if err := os.MkdirAll(runDir(cfg.RunID), 0o755); err != nil {
+			return fmt.Errorf("failed to create run dir: %w", err)
+		}
+		// go-git refuses to clone into a non-empty directory.
+		if err := clearSourceDir(src); err != nil {
+			return err
+		}
+		if err := cloneRepository(ctx, cfg, src); err != nil {
+			return err
+		}
+	case jobTypeApply:
+		// The plan pod is the only writer; confirm its tree is still here.
+		if err := validateSourceDir(src, cfg.TFPath); err != nil {
+			return err
+		}
 	}
 
-	if err := execTerraform(ctx, cfg, tmpDir); err != nil {
+	if err := execTerraform(ctx, cfg, src); err != nil {
 		return err
 	}
 

--- a/cmd/job/main.go
+++ b/cmd/job/main.go
@@ -145,47 +145,6 @@ func sourcePath(runID string) string {
 	return filepath.Join(runDir(runID), "source")
 }
 
-// clearSourceDir removes the working tree at path. No-op if it is absent.
-func clearSourceDir(path string) error {
-	if err := os.RemoveAll(path); err != nil {
-		return fmt.Errorf("failed to clear source dir %q: %w", path, err)
-	}
-	return nil
-}
-
-// pruneOldRunDirs removes every per-run directory on the PVC except the
-// one for currentRunID. The plan pod calls this at startup to clean up
-// orphans left by previous failed or interrupted runs.
-func pruneOldRunDirs(currentRunID string) error {
-	return pruneRunDirsIn(runsBase, currentRunID)
-}
-
-// pruneRunDirsIn removes every subdirectory in baseDir except the one
-// named currentRunID. Files in baseDir are left alone. A failure on one
-// entry is logged and skipped so a single bad entry does not block the
-// run. pruneOldRunDirs uses this with runsBase; tests pass a tempdir.
-func pruneRunDirsIn(baseDir, currentRunID string) error {
-	entries, err := os.ReadDir(baseDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to list run dirs in %q: %w", baseDir, err)
-	}
-	for _, e := range entries {
-		if !e.IsDir() || e.Name() == currentRunID {
-			continue
-		}
-		path := filepath.Join(baseDir, e.Name())
-		if err := os.RemoveAll(path); err != nil {
-			log.Printf("Warning: failed to prune stale run dir %s: %v", path, err)
-			continue
-		}
-		log.Printf("Pruned stale run dir %s", path)
-	}
-	return nil
-}
-
 // validateSourceDir checks that the apply pod's working tree is present
 // and that terraform init ran in it. Fails fast otherwise.
 func validateSourceDir(sourceDir, tfPath string) error {
@@ -217,8 +176,7 @@ func validateSourceDir(sourceDir, tfPath string) error {
 // dest and checks out the exact revision the controller asked for. The shallow
 // clone keeps pod startup fast and avoids pulling years of history the job is
 // never going to read. Only the plan pod calls this; the apply pod reuses the
-// working tree the plan pod produced. dest is expected to be empty or missing;
-// callers that may have a stale tree on disk should call clearSourceDir first.
+// working tree the plan pod produced. dest is expected to be empty or missing.
 func cloneRepository(ctx context.Context, cfg *Config, dest string) error {
 	auth, err := getAuthMethod(cfg)
 	if err != nil {
@@ -608,16 +566,14 @@ func run() error {
 
 	switch cfg.JobType {
 	case jobTypePlan:
-		// Best-effort cleanup of orphan run dirs.
-		if err := pruneOldRunDirs(cfg.RunID); err != nil {
-			log.Printf("Warning: failed to prune stale run dirs: %v", err)
+		// Start from a clean slate. The previous run's apply pod removes
+		// its own run dir on exit, but a wipe of runsBase covers the case
+		// where that defer never ran (pod killed, OOM, eviction).
+		if err := os.RemoveAll(runsBase); err != nil {
+			return fmt.Errorf("failed to clear runs dir: %w", err)
 		}
 		if err := os.MkdirAll(runDir(cfg.RunID), 0o755); err != nil {
 			return fmt.Errorf("failed to create run dir: %w", err)
-		}
-		// go-git refuses to clone into a non-empty directory.
-		if err := clearSourceDir(src); err != nil {
-			return err
 		}
 		if err := cloneRepository(ctx, cfg, src); err != nil {
 			return err

--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -828,6 +828,25 @@ func (r *WorkspaceReconciler) reconcileWorkspace(ctx context.Context, workspace 
 	// we fall through to Step 7 to decide whether to apply it.
 	if planJobGetErr != nil {
 		if errors.IsNotFound(planJobGetErr) {
+			// One Job per Workspace runs at a time. Wait for any
+			// previous Job to finish before creating a new plan Job.
+			var ownedJobs batchv1.JobList
+			if err := r.List(ctx, &ownedJobs, client.InNamespace(workspace.Namespace)); err != nil {
+				return ctrl.Result{}, err
+			}
+			for _, j := range ownedJobs.Items {
+				// Skip the current run's Jobs and any Job that is not running.
+				if j.Name == planJobName || j.Name == applyJobName || j.Status.Active == 0 {
+					continue
+				}
+				for _, owner := range j.OwnerReferences {
+					if owner.UID == workspace.UID {
+						logger.Info("Waiting for previous Job to finish")
+						return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+					}
+				}
+			}
+
 			logger.Info("Creating a new Plan Job", "job", planJobName)
 			runID := ensureRunMetadata(workspace)
 			newJob, err := r.constructJobForWorkspace(ctx, workspace, planJobName, jobTypePlan, planFile, pvcName, runID, resolvedVars)
@@ -1393,9 +1412,10 @@ func (r *WorkspaceReconciler) archiveRunLogs(
 // that Kubernetes resolves them at Pod startup from the referenced Secret, and
 // we never have to copy secret data into the Job spec.
 //
-// The Job mounts the Workspace's shared PVC at /workspace-data. The Plan Job
-// writes the .tfplan file there, and the Apply Job reads it back from the same
-// path.
+// The Job mounts the Workspace's shared PVC at /workspace-data. Each run
+// uses its own /workspace-data/runs/<runID>/ subdirectory. The Plan Job
+// clones into it and runs terraform init+plan; the Apply Job reuses that
+// tree without re-cloning. The directory is removed on a successful apply.
 //
 // We set backoffLimit to 0 so Kubernetes does not automatically retry a failed
 // Job. Terraform failures (bad HCL, provider errors, state locks) are unlikely
@@ -1406,15 +1426,24 @@ func (r *WorkspaceReconciler) archiveRunLogs(
 // garbage collection will delete it when the Workspace is removed.
 func (r *WorkspaceReconciler) constructJobForWorkspace(ctx context.Context, ws *v1alpha1.Workspace, jobName, jobType, planFile, pvcName, runID string, resolvedVars []variableset.ResolvedVariable) (*batchv1.Job, error) {
 	// The below map holds configuration that every Job needs: where to clone
-	// from, which revision to check out, which Terraform version to use, and
-	// whether this is a "plan" or "apply" run.
+	// from, which Terraform version to use, and whether this is a "plan" or
+	// "apply" run.
 	envVars := []corev1.EnvVar{
 		{Name: "REPO_URL", Value: ws.Spec.Source.RepoURL},
-		{Name: "TARGET_REVISION", Value: ws.Spec.Source.TargetRevision},
 		{Name: "TF_VERSION", Value: ws.Spec.Terraform.Version},
 		{Name: "PROJECT_REF", Value: ws.Spec.ProjectRef.Name},
 		{Name: "MAGOS_JOB_TYPE", Value: jobType},
 		{Name: "MAGOS_PLAN_FILE", Value: planFile},
+		// MAGOS_RUN_ID picks the per-run subdirectory on the PVC.
+		{Name: "MAGOS_RUN_ID", Value: runID},
+	}
+
+	// TARGET_REVISION is the git ref the plan pod checks out. The apply pod
+	// does not clone; it reuses the working tree the plan pod left at
+	// /workspace-data/source on the shared PVC, so the env var is set only
+	// on plan jobs.
+	if jobType == jobTypePlan {
+		envVars = append(envVars, corev1.EnvVar{Name: "TARGET_REVISION", Value: ws.Spec.Source.TargetRevision})
 	}
 
 	// Optional paths that narrow which Terraform directory to run in and which

--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -1412,10 +1412,9 @@ func (r *WorkspaceReconciler) archiveRunLogs(
 // that Kubernetes resolves them at Pod startup from the referenced Secret, and
 // we never have to copy secret data into the Job spec.
 //
-// The Job mounts the Workspace's shared PVC at /workspace-data. Each run
-// uses its own /workspace-data/runs/<runID>/ subdirectory. The Plan Job
-// clones into it and runs terraform init+plan; the Apply Job reuses that
-// tree without re-cloning. The directory is removed on a successful apply.
+// The Job mounts the Workspace's PVC at /workspace-data. The plan pod
+// clones into /workspace-data/runs/<runID>/source; the apply pod reuses
+// that tree and removes the run dir on exit.
 //
 // We set backoffLimit to 0 so Kubernetes does not automatically retry a failed
 // Job. Terraform failures (bad HCL, provider errors, state locks) are unlikely
@@ -1438,10 +1437,8 @@ func (r *WorkspaceReconciler) constructJobForWorkspace(ctx context.Context, ws *
 		{Name: "MAGOS_RUN_ID", Value: runID},
 	}
 
-	// TARGET_REVISION is the git ref the plan pod checks out. The apply pod
-	// does not clone; it reuses the working tree the plan pod left at
-	// /workspace-data/source on the shared PVC, so the env var is set only
-	// on plan jobs.
+	// Only the plan pod clones the repo. The apply pod reuses the
+	// working tree the plan pod produced.
 	if jobType == jobTypePlan {
 		envVars = append(envVars, corev1.EnvVar{Name: "TARGET_REVISION", Value: ws.Spec.Source.TargetRevision})
 	}


### PR DESCRIPTION
Each pod used to clone the repo and run `terraform init` independently, so the apply pod could land on a different commit than the plan pod when HEAD moved between them. The plan pod now writes the source and `.terraform/` directory to `/workspace-data/source` on the shared PVC, and the apply pod reuses that tree without cloning.