### PR TITLE
feat(job): add `SecurityContext` for both the job itself as the container

### DIFF
--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -1585,7 +1585,21 @@ func (r *WorkspaceReconciler) constructJobForWorkspace(ctx context.Context, ws *
 									MountPath: "/workspace-data",
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             new(true),
+								AllowPrivilegeEscalation: new(false),
+								ReadOnlyRootFilesystem:   new(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
 						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: new(true),
+						RunAsUser:    new(int64(10001)),
+						RunAsGroup:   new(int64(10001)),
+						FSGroup:      new(int64(10001)),
 					},
 				},
 			},

--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -1588,7 +1588,6 @@ func (r *WorkspaceReconciler) constructJobForWorkspace(ctx context.Context, ws *
 							SecurityContext: &corev1.SecurityContext{
 								RunAsNonRoot:             new(true),
 								AllowPrivilegeEscalation: new(false),
-								ReadOnlyRootFilesystem:   new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},


### PR DESCRIPTION
Closes https://github.com/magosproject/magos/issues/70

Adds a `SecurityContext` to both the pod as well as the container so that it is always ensured that they run as non-root user, even if the image tells otherwise.

Tested on my local system, and jobs still run fine.