### PR TITLE
Make workspace pvc size configurable with chart default

### DIFF
--- a/api/internal/api/docs/swagger.json
+++ b/api/internal/api/docs/swagger.json
@@ -1011,6 +1011,10 @@
                     "projectRef": {
                         "$ref": "#/components/schemas/v1alpha1.ProjectReference"
                     },
+                    "pvcSize": {
+                        "description": "PVCSize sets the requested storage size for the Workspace PVC used by\nplan/apply Jobs to share Terraform state artifacts and provider cache.\nWhen omitted, the controller default is used.\n+optional",
+                        "type": "string"
+                    },
                     "serviceAccountName": {
                         "description": "ServiceAccountName is the ServiceAccount that plan and apply Job pods\nrun under. The ServiceAccount must exist in the same namespace as the\nWorkspace. Defaults to magos-job, which the Helm chart creates with\nget;list;watch on validatingpolicies.policies.kyverno.io so the job can\nfetch ValidatingPolicies at runtime. Override this to run pods under a\ndifferent identity, for example to bind a GKE Workload Identity or AWS\nIRSA annotation; the replacement must carry the same RBAC.\n+kubebuilder:default=magos-job\n+optional",
                         "type": "string"

--- a/charts/magos/resources/crds/magosproject.io_workspaces.yaml
+++ b/charts/magos/resources/crds/magosproject.io_workspaces.yaml
@@ -115,6 +115,12 @@ spec:
                 required:
                 - name
                 type: object
+              pvcSize:
+                description: |-
+                  PVCSize sets the requested storage size for the Workspace PVC used by
+                  plan/apply Jobs to share Terraform state artifacts and provider cache.
+                  When omitted, the controller default is used.
+                type: string
               serviceAccountName:
                 default: magos-job
                 description: |-

--- a/charts/magos/templates/deployment.yaml
+++ b/charts/magos/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
         {{- if eq $name "workspace" }}
         - name: MAGOS_JOB_IMAGE
           value: "{{ $root.Values.jobImage.repository }}:{{ $root.Values.jobImage.tag | default $root.Chart.AppVersion }}"
+        - name: MAGOS_WORKSPACE_PVC_SIZE_DEFAULT
+          value: {{ $root.Values.workspace.defaultPVCSize | quote }}
         {{- if not (($root.Values.job).colorOutput | default true) }}
         - name: NO_COLOR
           value: "1"

--- a/charts/magos/values.yaml
+++ b/charts/magos/values.yaml
@@ -182,6 +182,10 @@ job:
   # the workspace controller, which forwards it to every job pod).
   colorOutput: true
 
+workspace:
+  # defaultPVCSize is used when a Workspace does not set spec.pvcSize.
+  defaultPVCSize: 1Gi
+
 logs:
   storage:
     image:

--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -65,6 +65,10 @@ const (
 	// indefinitely if a Job hangs (e.g. terraform blocks on a provider call).
 	DefaultJobTimeoutSeconds int64 = 86400 // 24 hours
 
+	// DefaultWorkspacePVCSize is the storage request used for Workspace PVCs
+	// when neither the Workspace spec nor controller config provides a value.
+	DefaultWorkspacePVCSize = "1Gi"
+
 	// jobTypePlan and jobTypeApply are the two values the workspace controller
 	// uses when launching a Kubernetes Job. The value is written into the
 	// MAGOS_JOB_TYPE environment variable so the job knows whether to run
@@ -1129,6 +1133,11 @@ func (r *WorkspaceReconciler) ensurePVC(ctx context.Context, ws *v1alpha1.Worksp
 
 	if err != nil && errors.IsNotFound(err) {
 		log.FromContext(ctx).Info("Creating PVC for Workspace", "pvc", pvcName)
+		requestedPVCSize := r.resolveWorkspacePVCSize(ws)
+		requestedStorage, parseErr := resource.ParseQuantity(requestedPVCSize)
+		if parseErr != nil {
+			return fmt.Errorf("invalid workspace PVC size %q: %w", requestedPVCSize, parseErr)
+		}
 
 		newPVC := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1139,7 +1148,7 @@ func (r *WorkspaceReconciler) ensurePVC(ctx context.Context, ws *v1alpha1.Worksp
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
+						corev1.ResourceStorage: requestedStorage,
 					},
 				},
 			},
@@ -1154,6 +1163,16 @@ func (r *WorkspaceReconciler) ensurePVC(ctx context.Context, ws *v1alpha1.Worksp
 		return r.Create(ctx, newPVC)
 	}
 	return err
+}
+
+func (r *WorkspaceReconciler) resolveWorkspacePVCSize(ws *v1alpha1.Workspace) string {
+	if ws.Spec.PVCSize != "" {
+		return ws.Spec.PVCSize
+	}
+	if defaultPVCSize := os.Getenv("MAGOS_WORKSPACE_PVC_SIZE_DEFAULT"); defaultPVCSize != "" {
+		return defaultPVCSize
+	}
+	return DefaultWorkspacePVCSize
 }
 
 // resolveEffectivePolicySelector determines the label selector string for
@@ -1765,6 +1784,12 @@ func (r *WorkspaceReconciler) updateNextReconcileTime(ctx context.Context, works
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if defaultPVCSize := os.Getenv("MAGOS_WORKSPACE_PVC_SIZE_DEFAULT"); defaultPVCSize != "" {
+		if _, err := resource.ParseQuantity(defaultPVCSize); err != nil {
+			return fmt.Errorf("invalid MAGOS_WORKSPACE_PVC_SIZE_DEFAULT %q: %w", defaultPVCSize, err)
+		}
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Workspace{}).
 		Owns(&batchv1.Job{}).                  // Watch for changes to Jobs owned by the Workspace

--- a/internal/controller/workspace/workspace_controller_test.go
+++ b/internal/controller/workspace/workspace_controller_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026. The Magos Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+package workspace
+
+import (
+	"testing"
+
+	"github.com/magosproject/magos/types/magosproject/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveWorkspacePVCSizeUsesWorkspaceSpec(t *testing.T) {
+	t.Setenv("MAGOS_WORKSPACE_PVC_SIZE_DEFAULT", "2Gi")
+	reconciler := WorkspaceReconciler{}
+	workspace := &v1alpha1.Workspace{
+		Spec: v1alpha1.WorkspaceSpec{
+			PVCSize: "7Gi",
+		},
+	}
+
+	assert.Equal(t, "7Gi", reconciler.resolveWorkspacePVCSize(workspace))
+}
+
+func TestResolveWorkspacePVCSizeUsesEnvDefault(t *testing.T) {
+	t.Setenv("MAGOS_WORKSPACE_PVC_SIZE_DEFAULT", "3Gi")
+	reconciler := WorkspaceReconciler{}
+
+	assert.Equal(t, "3Gi", reconciler.resolveWorkspacePVCSize(&v1alpha1.Workspace{}))
+}
+
+func TestResolveWorkspacePVCSizeFallsBackToBuiltInDefault(t *testing.T) {
+	t.Setenv("MAGOS_WORKSPACE_PVC_SIZE_DEFAULT", "")
+	reconciler := WorkspaceReconciler{}
+
+	assert.Equal(t, DefaultWorkspacePVCSize, reconciler.resolveWorkspacePVCSize(&v1alpha1.Workspace{}))
+}

--- a/types/magosproject/v1alpha1/workspace_types.go
+++ b/types/magosproject/v1alpha1/workspace_types.go
@@ -170,6 +170,12 @@ type WorkspaceSpec struct {
 	// +kubebuilder:default=magos-job
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// PVCSize sets the requested storage size for the Workspace PVC used by
+	// plan/apply Jobs to share Terraform state artifacts and provider cache.
+	// When omitted, the controller default is used.
+	// +optional
+	PVCSize string `json:"pvcSize,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace.

--- a/ui/app/api/types.gen.ts
+++ b/ui/app/api/types.gen.ts
@@ -1947,6 +1947,13 @@ export interface components {
             plan?: components["schemas"]["v1alpha1.JobOverrides"];
             projectRef?: components["schemas"]["v1alpha1.ProjectReference"];
             /**
+             * @description PVCSize sets the requested storage size for the Workspace PVC used by
+             *     plan/apply Jobs to share Terraform state artifacts and provider cache.
+             *     When omitted, the controller default is used.
+             *     +optional
+             */
+            pvcSize?: string;
+            /**
              * @description ServiceAccountName is the ServiceAccount that plan and apply Job pods
              *     run under. The ServiceAccount must exist in the same namespace as the
              *     Workspace. Defaults to magos-job, which the Helm chart creates with


### PR DESCRIPTION
Closes #75
Relates to #68

#### AI disclaimer:

This was a fairly straightforward issue, so I let an agent work through most of it while I focused on other work.

Appreciate GitHub Copilot for helping with the implementation, but I’m merging this under my own name after reviewing and understanding the changes. Long term, maintainability and accountability still sit with the maintainers, especially when community members run into issues, have questions, or need follow-up fixes months from now.