### PR TITLE
workspace: normalize url that trims surrounding whitespace, a trailing slash, a trailing `.git`

### DIFF
--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -101,6 +101,16 @@ type WorkspaceReconciler struct {
 	RunRecorder RunRecorder
 }
 
+// normalizeRepoURL trims whitespace, a trailing slash, and a single .git
+// suffix so URLs that differ only in style match as the same repository.
+func normalizeRepoURL(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimSuffix(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	u = strings.TrimSuffix(u, "/")
+	return u
+}
+
 // getRepoCredentials finds the Git credential Secret for a given repository
 // URL. Magos uses a convention where credential Secrets are labeled with
 // magosproject.io/secret-type=repository and contain a "repoURL" data key that
@@ -120,10 +130,12 @@ func (r *WorkspaceReconciler) getRepoCredentials(ctx context.Context, namespace,
 		return nil, err
 	}
 
+	target := normalizeRepoURL(targetRepoURL)
+
 	// Find the secret that matches the requested RepoURL
 	for i := range secretList.Items {
 		secret := &secretList.Items[i]
-		if string(secret.Data[SecretKeyRepoURL]) == targetRepoURL {
+		if normalizeRepoURL(string(secret.Data[SecretKeyRepoURL])) == target {
 			return secret, nil
 		}
 	}
@@ -165,9 +177,10 @@ func (r *WorkspaceReconciler) findWorkspacesForSecret(ctx context.Context, o cli
 	// For each workspace in the same namespace, if its Spec.Source.RepoURL
 	// matches the repoURL from the secret, enqueue a reconcile request for that
 	// workspace.
+	target := normalizeRepoURL(string(repoURL))
 	var requests []reconcile.Request
 	for _, ws := range workspaces.Items {
-		if ws.Spec.Source.RepoURL == string(repoURL) {
+		if normalizeRepoURL(ws.Spec.Source.RepoURL) == target {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      ws.Name,

--- a/internal/controller/workspace/workspace_controller_test.go
+++ b/internal/controller/workspace/workspace_controller_test.go
@@ -47,3 +47,31 @@ func TestResolveWorkspacePVCSizeFallsBackToBuiltInDefault(t *testing.T) {
 
 	assert.Equal(t, DefaultWorkspacePVCSize, reconciler.resolveWorkspacePVCSize(&v1alpha1.Workspace{}))
 }
+
+func TestNormalizeRepoURLStripsGitSuffix(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar", normalizeRepoURL("https://github.com/foo/bar.git"))
+}
+
+func TestNormalizeRepoURLLeavesPlainURLUnchanged(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar", normalizeRepoURL("https://github.com/foo/bar"))
+}
+
+func TestNormalizeRepoURLStripsTrailingSlash(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar", normalizeRepoURL("https://github.com/foo/bar/"))
+}
+
+func TestNormalizeRepoURLStripsTrailingSlashAfterGitSuffix(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar", normalizeRepoURL("https://github.com/foo/bar.git/"))
+}
+
+func TestNormalizeRepoURLStripsSurroundingWhitespace(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar", normalizeRepoURL("  https://github.com/foo/bar.git  "))
+}
+
+func TestNormalizeRepoURLHandlesSSHForm(t *testing.T) {
+	assert.Equal(t, "git@github.com:foo/bar", normalizeRepoURL("git@github.com:foo/bar.git"))
+}
+
+func TestNormalizeRepoURLDoesNotStripGitInsidePath(t *testing.T) {
+	assert.Equal(t, "https://github.com/foo/bar.gitlab", normalizeRepoURL("https://github.com/foo/bar.gitlab"))
+}


### PR DESCRIPTION
Closes #74 

Credential lookup and secret-to-workspace mapping compared `RepoURL` by exact string, so `https://github.com/foo/bar` and `https://github.com/foo/bar.git` were treated as different repos.