### PR TITLE
feat(nginx): support HTTP 2.0 for proxying requests between UI and API

### DIFF
--- a/ui/nginx.conf.template
+++ b/ui/nginx.conf.template
@@ -32,7 +32,7 @@ http {
 
         location /apis/ {
             proxy_pass http://${MAGOS_API_HOST}:${MAGOS_API_PORT};
-            proxy_http_version 1.1;
+            proxy_http_version 2;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -53,4 +53,3 @@ http {
         }
     }
 }
-


### PR DESCRIPTION
Closes https://github.com/magosproject/magos/issues/24

Allowing the browser to connect over HTTP 2.0 to the API.