### PR TITLE
fix(chart): API doesn't have permission to read pod logs - causing logs SSE streams to fail

### DIFF
--- a/charts/magos/templates/api/cluster-role.yaml
+++ b/charts/magos/templates/api/cluster-role.yaml
@@ -20,4 +20,18 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 {{- end }}


### PR DESCRIPTION
With the chart refactor some Kubernetes IAM permssions were lost, because of this the API wasn't able to fetch logs directly anymore. Therefore the log stream did not work, however the log fetch did work. Reason for that is because the log fetch reads from S3 where the controller writes,  so therefore the API did not need direct k8s pod read API access.